### PR TITLE
fixed bug of ignoring 'order' column

### DIFF
--- a/src/Controller/Component/FlexpagerComponent.php
+++ b/src/Controller/Component/FlexpagerComponent.php
@@ -47,7 +47,7 @@ class FlexpagerComponent extends PaginatorComponent
         if (!empty($this->_listCandidates)) {
             $this->controller->set('listCandidates', $this->_listCandidates);
         }
-        return parent::paginate($object, $settings);
+        return parent::paginate($object, $this->_defaultConfig);
     }
 
     /**


### PR DESCRIPTION
for example,
in Controller
```
public $paginate = [
        'order' => [
            'Users.id' => 'asc,
        ],
    ];
```
was not working because of the defect on delivery system of options.
I fix the bug on this branch.

the emergency level of this bug is high, so I merge it,
though in some day, I have to re-consider on this issue.