### PR TITLE
core/PaginatorHelper::numbers() was extended

### DIFF
--- a/src/View/Helper/FlexpaginatorHelper.php
+++ b/src/View/Helper/FlexpaginatorHelper.php
@@ -77,4 +77,21 @@ class FlexpaginatorHelper extends PaginatorHelper
         }
         $this->flexPagerTemplate = $string;
     }
+    
+    /**
+     * numbers follow the settings for limit.
+     *
+     * @param array $options
+     *
+     * @return string URL created by parent
+     */
+    public function numbers(array $options = [])
+    {
+        $currentLimit = $this->_View->get('currentLimit');
+        if (empty($options['url']['limit'])) {
+            $options['url']['limit'] = $currentLimit;
+        }
+
+        return parent::numbers($options);
+    }
 }


### PR DESCRIPTION
The URL created by `parent::numbers()` was not enough.
By this commit, the limit will be automatically added like shown below.
```
<li><a href="/Flexpager/flexpager-test/users?limit=10">1</a></li>
<li class="active"><a href="">2</a></li>
<li><a href="/Flexpager/flexpager-test/users?page=3&amp;limit=10">3</a></li>
<li><a href="/Flexpager/flexpager-test/users?page=4&amp;limit=10">4</a></li>
<li><a href="/Flexpager/flexpager-test/users?page=5&amp;limit=10">5</a></li>
<li><a href="/Flexpager/flexpager-test/users?page=6&amp;limit=10">6</a></li>
<li><a href="/Flexpager/flexpager-test/users?page=7&amp;limit=10">7</a></li>
<li><a href="/Flexpager/flexpager-test/users?page=8&amp;limit=10">8</a></li>
<li><a href="/Flexpager/flexpager-test/users?page=9&amp;limit=10">9</a></li>
```