### PR TITLE
ページネートの見え方改修

### DIFF
--- a/src/Controller/Component/FlexpagerComponent.php
+++ b/src/Controller/Component/FlexpagerComponent.php
@@ -3,6 +3,7 @@
 namespace Flexpager\Controller\Component;
 
 use Cake\Controller\Component\PaginatorComponent;
+use Cake\Datasource\QueryInterface;
 use Cake\Routing\Router;
 
 class FlexpagerComponent extends PaginatorComponent
@@ -41,7 +42,7 @@ class FlexpagerComponent extends PaginatorComponent
         }
 
         // create url.
-        $urlLinkForFlexPaginator = $this->urlForHelper();
+        $urlLinkForFlexPaginator = $this->urlForHelper($object, $this->_defaultConfig);
         $this->controller->set('flexUrl', $urlLinkForFlexPaginator);
 
         if (!empty($this->_listCandidates)) {
@@ -76,8 +77,16 @@ class FlexpagerComponent extends PaginatorComponent
      *
      * @return [array] Url
      */
-    private function urlForHelper()
+    private function urlForHelper($object, $settings)
     {
+        // limit取得用にparentのpaginateメソッドからコピペ
+        if ($object instanceof QueryInterface) {
+            $query = $object;
+            $object = $query->repository();
+        }
+
+        $alias = $object->alias();
+        $options = $this->mergeOptions($alias, $settings);
         // requestからURL情報を取得
         $urlArray = $this->controller->request->params;
         // pass情報をURLにセットする形に修正
@@ -96,7 +105,7 @@ class FlexpagerComponent extends PaginatorComponent
             $this->controller->set('currentLimit', $urlArray['limit']);
             unset($urlArray['limit']);
         } else {
-            $this->controller->set('currentLimit', $this->_config['limit']);
+            $this->controller->set('currentLimit', $options['limit']);
         }
         return $urlArray;
     }

--- a/src/Controller/Component/FlexpagerComponent.php
+++ b/src/Controller/Component/FlexpagerComponent.php
@@ -91,6 +91,13 @@ class FlexpagerComponent extends PaginatorComponent
         unset($urlArray['pass']);
         // page情報は引き継がない
         unset($urlArray['page']);
+        // limit情報をセットする
+        if (!empty($urlArray['limit'])) {
+            $this->controller->set('currentLimit', $urlArray['limit']);
+            unset($urlArray['limit']);
+        } else {
+            $this->controller->set('currentLimit', $this->_config['limit']);
+        }
         return $urlArray;
     }
 }

--- a/src/Controller/Component/FlexpagerComponent.php
+++ b/src/Controller/Component/FlexpagerComponent.php
@@ -74,51 +74,23 @@ class FlexpagerComponent extends PaginatorComponent
     /**
      * urlForHelper create Urls For Helper.
      *
-     * @return [string] Url
+     * @return [array] Url
      */
     private function urlForHelper()
     {
-        $url = Router::url(null, true);
-
-        $query = $this->request->query;
-
-        if (!empty($query['limit'])) {
-            $this->controller->set('currentLimit', $query['limit']);
-            unset($query['limit']);
-        }
-
-        if (!empty($query['page'])) {
-            unset($query['page']);
-        }
-
-        $isFirstIterate = false;
-        foreach ($query as $key => $value) {
-            if (!$isFirstIterate) {
-                if (is_array($value)) {
-                    foreach ($value as $key => $value) {
-                        if (!$isFirstIterate) {
-                            $url .= '?'.$value.'='.$key.'.'.$value;
-                            $isFirstIterate = true;
-                        } else {
-                            $url .= '&'.$value.'='.$key.'.'.$value;
-                        }
-                    }
-                } else {
-                    $url .= '?'.$key.'='.$value;
-                    $isFirstIterate = true;
-                }
-            } else {
-                if (is_array($value)) {
-                    foreach ($value as $key => $value) {
-                        $url .= '&'.$value.'='.$key.'.'.$value;
-                    }
-                } else {
-                    $url .= '&'.$key.'='.$value;
-                }
-            }
-        }
-
-
-        return $url;
+        // requestからURL情報を取得
+        $urlArray = $this->controller->request->params;
+        // pass情報をURLにセットする形に修正
+        $urlArray = array_merge($urlArray, $urlArray['pass']);
+        // query情報をセット
+        $urlArray = array_merge($urlArray, $this->request->query);
+        // 不要な情報をunset
+        unset($urlArray['_matchedRoute']);
+        unset($urlArray['_ext']);
+        unset($urlArray['isAjax']);
+        unset($urlArray['pass']);
+        // page情報は引き継がない
+        unset($urlArray['page']);
+        return $urlArray;
     }
 }

--- a/src/View/Helper/FlexpaginatorHelper.php
+++ b/src/View/Helper/FlexpaginatorHelper.php
@@ -18,6 +18,9 @@ use Cake\View\Helper\PaginatorHelper;
 class FlexpaginatorHelper extends PaginatorHelper
 {
     protected $flexPagerTemplate = '<a href={{url}}>{{content}}</a>';
+    protected $flexActivePagerTemplate = '<a href="#" class="active">{{content}}</a>';
+    protected $flexPagerFooter = '';
+    protected $defaultPagerLimit = 20;
 
     public function limitCandidate()
     {
@@ -44,21 +47,24 @@ class FlexpaginatorHelper extends PaginatorHelper
         // current Url Except For limit.
         $flexUrl = $this->_View->get('flexUrl');
         $currentLimit = $this->_View->get('currentLimit');
+        if (empty($currentLimit)) {
+            $currentLimit = $this->defaultPagerLimit;
+        }
 
         $conjunction = strpos($flexUrl, '?') ? '&' : '?';
 
         $result = '';
         foreach ($listCandidates as $candidates) {
             if ($candidates == $currentLimit) {
-                continue;
+                $result .= preg_replace('/{{content}}/', $candidates . $this->flexPagerFooter, $this->flexActivePagerTemplate);
+            } else {
+                $url = $flexUrl.$conjunction.'limit='.$candidates;
+
+                $href = preg_replace('/{{url}}/', $url, $this->flexPagerTemplate);
+                $href = preg_replace('/{{content}}/', $candidates . $this->flexPagerFooter, $href);
+
+                $result .= $href;
             }
-            $url = $flexUrl.$conjunction.'limit='.$candidates;
-            $url = h($flexUrl.$conjunction.'limit='.$candidates);
-
-            $href = preg_replace('/{{url}}/', $url, $this->flexPagerTemplate);
-            $href = preg_replace('/{{content}}/', $candidates, $href);
-
-            $result .= $href;
         }
 
         return $result;
@@ -78,6 +84,37 @@ class FlexpaginatorHelper extends PaginatorHelper
         }
         $this->flexPagerTemplate = $string;
     }
+
+    /**
+     * setActiveFlexPagerTemplate modify the original template
+     * @param [string] $string must include "{{url}}" and "{{content}}".
+     */
+    public function setActiveFlexPagerTemplate($string)
+    {
+        if (!strpos($string, '{{content}}')) {
+            throw new \Exception('"{{content}}" is not included.');
+        }
+        $this->flexActivePagerTemplate = $string;
+    }
+
+    /**
+     * setFlexPagerFooter modify the original template
+     * @param [string] $string must include "{{url}}" and "{{content}}".
+     */
+    public function setFlexPagerFooter($string)
+    {
+        $this->flexPagerFooter = $string;
+    }
+
+    /**
+     * setFlexPagerFooter modify the original template
+     * @param [string] $string must include "{{url}}" and "{{content}}".
+     */
+    public function setDefaultPagerLimit($string)
+    {
+        $this->defaultPagerLimit = $string;
+    }
+
 
     /**
      * numbers follow the settings for limit.

--- a/src/View/Helper/FlexpaginatorHelper.php
+++ b/src/View/Helper/FlexpaginatorHelper.php
@@ -21,7 +21,6 @@ class FlexpaginatorHelper extends PaginatorHelper
     protected $flexPagerTemplate = '<a href={{url}}>{{content}}</a>';
     protected $flexActivePagerTemplate = '<a href="#" class="active">{{content}}</a>';
     protected $flexPagerFooter = '';
-    protected $defaultPagerLimit = 20;
 
     public function limitCandidate()
     {
@@ -48,9 +47,6 @@ class FlexpaginatorHelper extends PaginatorHelper
         // current Url Except For limit.
         $flexUrl = $this->_View->get('flexUrl');
         $currentLimit = $this->_View->get('currentLimit');
-        if (empty($currentLimit)) {
-            $currentLimit = $this->defaultPagerLimit;
-        }
 
         $result = '';
         foreach ($listCandidates as $candidates) {
@@ -106,16 +102,6 @@ class FlexpaginatorHelper extends PaginatorHelper
     {
         $this->flexPagerFooter = $string;
     }
-
-    /**
-     * setFlexPagerFooter modify the original template
-     * @param [string] $string must include "{{url}}" and "{{content}}".
-     */
-    public function setDefaultPagerLimit($string)
-    {
-        $this->defaultPagerLimit = $string;
-    }
-
 
     /**
      * numbers follow the settings for limit.

--- a/src/View/Helper/FlexpaginatorHelper.php
+++ b/src/View/Helper/FlexpaginatorHelper.php
@@ -3,6 +3,7 @@
 namespace Flexpager\View\Helper;
 
 use Cake\View\Helper\PaginatorHelper;
+use Cake\Routing\Router;
 
 /**
  * Pagination Helper class for easy generation of pagination links.
@@ -51,14 +52,14 @@ class FlexpaginatorHelper extends PaginatorHelper
             $currentLimit = $this->defaultPagerLimit;
         }
 
-        $conjunction = strpos($flexUrl, '?') ? '&' : '?';
-
         $result = '';
         foreach ($listCandidates as $candidates) {
             if ($candidates == $currentLimit) {
                 $result .= preg_replace('/{{content}}/', $candidates . $this->flexPagerFooter, $this->flexActivePagerTemplate);
             } else {
-                $url = $flexUrl.$conjunction.'limit='.$candidates;
+                // limit情報をセット
+                $flexUrl['limit'] = $candidates;
+                $url = Router::url($flexUrl);
 
                 $href = preg_replace('/{{url}}/', $url, $this->flexPagerTemplate);
                 $href = preg_replace('/{{content}}/', $candidates . $this->flexPagerFooter, $href);


### PR DESCRIPTION
```
<?= $this->Flexpaginator->setFlexPagerTemplate('<li><a href={{url}}>{{content}}</a></li>') ?>
<?= $this->Flexpaginator->setActiveFlexPagerTemplate('<li class="active"><a href="#">{{content}}</a></li>') ?>
<?= $this->Flexpaginator->setFlexPagerFooter('件表示') ?>
<div class="dataTables_paginate paging_simple_numbers" >
  <ul class="pagination">
    <?= $this->Flexpaginator->limitCandidate() ?>
  </ul>
</div>
```

でこうなる。

![2017-03-17_17h30_21](https://cloud.githubusercontent.com/assets/738095/24035096/6b6b5b70-0b37-11e7-9910-6e670b69888a.png)
